### PR TITLE
Add get_robot_state_stream method to BaseRobotInterface

### DIFF
--- a/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/python/polymetis/robot_interface.py
@@ -174,6 +174,10 @@ class BaseRobotInterface:
         """Returns the latest RobotState."""
         return self.grpc_connection.GetRobotState(EMPTY)
 
+    def get_robot_state_stream(self) -> Generator[RobotState, None, None]:
+        """Returns a stream of RobotStates."""
+        return self.grpc_connection.GetRobotStateStream(EMPTY)
+
     def get_previous_interval(self, timeout: float = None) -> LogInterval:
         """Get the log indices associated with the currently running policy."""
         log_interval = self.grpc_connection.GetEpisodeInterval(EMPTY)


### PR DESCRIPTION
Fixes issue #11  .

## Changes proposed:

- adding a method that returns the state stream as a generator object

